### PR TITLE
chore(site): add UTM drift guard for Discord CTA

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -70,7 +70,14 @@
       "Bash(NO_NETWORK=1 npm run test:branding)",
       "Bash(gh pr create:*)",
       "Bash(gh release list:*)",
-      "Bash(gh release view:*)"
+      "Bash(gh release view:*)",
+      "Bash(for f in site/index.html site/public/index.html)",
+      "Bash(do)",
+      "Bash([ -f \"$f\" ])",
+      "Bash(continue)",
+      "Bash(chmod:*)",
+      "Bash(./scripts/guard-no-linkedin.sh:*)",
+      "Bash(./tests/check-discord-cta.sh:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -77,7 +77,8 @@
       "Bash(continue)",
       "Bash(chmod:*)",
       "Bash(./scripts/guard-no-linkedin.sh:*)",
-      "Bash(./tests/check-discord-cta.sh:*)"
+      "Bash(./tests/check-discord-cta.sh:*)",
+      "Bash(./tests/assert-discord-url-exact.sh:*)"
     ],
     "deny": [],
     "ask": []

--- a/components/discord-cta.html
+++ b/components/discord-cta.html
@@ -1,0 +1,28 @@
+<!-- VIPSpot • Neon Discord CTA (unified, polished) -->
+<a
+  id="vip-discord"
+  class="vip-discord"
+  href="https://discord.gg/FJxrnAcawn?utm_source=vipspot&utm_medium=footer&utm_campaign=social_discord"
+  target="_blank"
+  rel="noopener"
+  aria-label="Join the VIPSpot Discord"
+>
+  <!-- Halo / orb behind the button -->
+  <div class="orb" aria-hidden="true">
+    <span class="ring"></span>
+    <span class="sheen"></span>
+    <span class="dot d1"></span>
+    <span class="dot d2"></span>
+    <span class="dot d3"></span>
+  </div>
+
+  <!-- Unified core (moves together) -->
+  <div class="btn-core">
+    <span class="pill" role="img" aria-label="Discord">
+      <svg class="ico" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M20.317 4.369a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.211.375-.444.864-.608 1.249a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.249.077.077 0 00-.079-.037 19.736 19.736 0 00-4.885 1.515.07.07 0 00-.032.027C.533 9.045-.32 13.579.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.027c.462-.63.873-1.295 1.226-1.994a.076.076 0 00-.041-.105 12.875 12.875 0 01-1.826-.878.077.077 0 01-.008-.128c.122-.091.244-.186.361-.28a.074.074 0 01.078-.01c3.832 1.748 7.97 1.748 11.762 0a.074.074 0 01.079.01c.118.094.24.189.361.28a.077.077 0 01-.006.128 12.5 12.5 0 01-1.827.878.076.076 0 00-.04.105c.36.698.771 1.364 1.225 1.994a.076.076 0 00.084.028 19.876 19.876 0 005.993-3.03.077.077 0 00.031-.056c.5-5.177-.838-9.673-3.549-13.661a.061.061 0 00-.031-.028zM8.02 15.331c-1.183 0-2.156-1.085-2.156-2.419 0-1.333.955-2.419 2.156-2.419 1.21 0 2.176 1.096 2.156 2.419 0 1.334-.955 2.419-2.156 2.419zm7.984 0c-1.183 0-2.156-1.085-2.156-2.419 0-1.333.955-2.419 2.156-2.419 1.21 0 2.176 1.096 2.156 2.419 0 1.334-.946 2.419-2.156 2.419z"/>
+      </svg>
+      <span class="txt">Join our Discord</span>
+    </span>
+  </div>
+</a>

--- a/css/discord-cta.css
+++ b/css/discord-cta.css
@@ -1,0 +1,67 @@
+:root{
+  --bg-0:#0b0f17;
+  --bg-1:#0f1527;
+  --ink:#e8fbff;
+  --muted:#9fb3c1;
+  --vip-cyan:#00e6c3;
+  --ring:#0ef;
+  --glare:#86fff0;
+  --pill-ink:#00312d;
+}
+.vip-discord{
+  --size: 300px; position:relative; display:grid; place-items:center;
+  width:var(--size); height:var(--size); text-decoration:none;
+  transform-style:preserve-3d; perspective:900px; color:var(--ink);
+}
+.orb{ position:absolute; inset:0; border-radius:50%; z-index:0;
+  background:
+    radial-gradient(55% 45% at 35% 35%, rgba(0,255,235,.22), transparent 60%),
+    radial-gradient(65% 55% at 65% 60%, rgba(0,130,255,.18), transparent 65%),
+    radial-gradient(100% 85% at 50% 60%, rgba(0,0,0,.55), rgba(0,0,0,.25));
+  box-shadow:0 0 0 1px rgba(160,240,255,.25) inset, 0 18px 36px rgba(0,255,235,.14);
+}
+.ring{ position:absolute; inset:10px; border-radius:50%;
+  background: conic-gradient(from 0deg, transparent 0 330deg, rgba(0,255,255,.28) 360deg);
+  box-shadow:0 0 0 1px rgba(160,240,255,.35) inset, 0 0 32px rgba(0,255,255,.15);
+  animation: discord_spin 24s linear infinite;
+}
+@keyframes discord_spin { to { transform: rotate(360deg); } }
+.sheen{ position:absolute; inset:0; border-radius:50%;
+  background: radial-gradient(120px 60px at 50% 8%, rgba(255,255,255,.25), transparent 60%);
+  mix-blend-mode: screen; pointer-events:none;
+}
+.dot{ position:absolute; left:50%; top:50%; width:8px; height:8px; margin:-4px 0 0 -4px;
+  border-radius:50%; background:var(--glare); box-shadow:0 0 16px 6px rgba(134,255,240,.25);
+  transform-origin:-112px 0; animation: discord_orbit 12s linear infinite; z-index:0;
+}
+.d1{ transform-origin:-120px 0; animation-duration:12s; }
+.d2{ transform-origin:-108px 0; animation-duration:10s; }
+.d3{ transform-origin:-116px 0; animation-duration:14s; }
+@keyframes discord_orbit { to { transform: rotate(360deg); } }
+
+.btn-core{ --lift:0px; --sca:1; position:relative; z-index:2;
+  transform: translateZ(1px) translateY(calc(-2px - var(--lift))) scale(var(--sca));
+  transition: transform .28s cubic-bezier(.2,.7,.2,1);
+}
+.pill{
+  display:inline-grid; grid-auto-flow:column; align-items:center; gap:.6rem;
+  padding:.95rem 1.25rem; min-width:180px; border-radius:999px;
+  color:var(--pill-ink); text-align:center; font-weight:700; letter-spacing:.2px; line-height:1;
+  background:linear-gradient(180deg, #2fffe3, var(--vip-cyan));
+  box-shadow:0 16px 28px rgba(0,255,235,.24), 0 2px 0 rgba(0,0,0,.18) inset, 0 -2px 10px rgba(255,255,255,.38) inset;
+  filter: drop-shadow(0 8px 18px rgba(0,255,235,.35));
+  animation: discord_breathe 3s ease-in-out infinite;
+}
+.ico{ width:26px; height:26px; color:#eaffff; flex:0 0 26px;
+  filter: drop-shadow(0 6px 12px rgba(255,255,255,.25));
+  transition: transform .25s ease, filter .25s ease;
+}
+@keyframes discord_breathe { 0%,100%{ transform:scale(1) } 50%{ transform:scale(1.02) } }
+
+.vip-discord:hover .btn-core, .vip-discord:focus-visible .btn-core { --lift:6px; --sca:1.04; }
+.vip-discord:hover .ico, .vip-discord:focus-visible .ico { transform:translateY(-1px) scale(1.06); filter: drop-shadow(0 10px 22px rgba(255,255,255,.35)); }
+.vip-discord:focus-visible{ outline:none; }
+
+@media (prefers-reduced-motion:reduce){
+  .ring,.dot,.pill{ animation:none; }
+}

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     
     <!-- Plausible Analytics (Privacy-first, no cookies) -->
     <script defer data-domain="vipspot.net" src="https://plausible.io/js/script.js"></script>
+  <link rel="stylesheet" href="css/discord-cta.css">
 </head>
 <body class="font-robotoMono">
     <!-- Skip Navigation Link -->
@@ -490,10 +491,10 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.linkedin.com/in/YOUR-HANDLE" class="social-link" target="_blank" rel="noopener" aria-label="LinkedIn">
+                        
                             <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#linkedin"></use></svg>
                             <span class="sr-only">LinkedIn</span>
-                        </a>
+                        
                     </li>
                     <li>
                         <a
@@ -554,7 +555,37 @@
                 </div>
             </div>
         </div>
-    </footer>
+      
+  <!-- Discord CTA -->
+  <!-- VIPSpot • Neon Discord CTA (unified, polished) -->
+<a
+  id="vip-discord"
+  class="vip-discord"
+  href="https://discord.gg/FJxrnAcawn?utm_source=vipspot&utm_medium=footer&utm_campaign=social_discord"
+  target="_blank"
+  rel="noopener"
+  aria-label="Join the VIPSpot Discord"
+>
+  <!-- Halo / orb behind the button -->
+  <div class="orb" aria-hidden="true">
+    <span class="ring"></span>
+    <span class="sheen"></span>
+    <span class="dot d1"></span>
+    <span class="dot d2"></span>
+    <span class="dot d3"></span>
+  </div>
+
+  <!-- Unified core (moves together) -->
+  <div class="btn-core">
+    <span class="pill" role="img" aria-label="Discord">
+      <svg class="ico" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M20.317 4.369a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.211.375-.444.864-.608 1.249a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.249.077.077 0 00-.079-.037 19.736 19.736 0 00-4.885 1.515.07.07 0 00-.032.027C.533 9.045-.32 13.579.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.027c.462-.63.873-1.295 1.226-1.994a.076.076 0 00-.041-.105 12.875 12.875 0 01-1.826-.878.077.077 0 01-.008-.128c.122-.091.244-.186.361-.28a.074.074 0 01.078-.01c3.832 1.748 7.97 1.748 11.762 0a.074.074 0 01.079.01c.118.094.24.189.361.28a.077.077 0 01-.006.128 12.5 12.5 0 01-1.827.878.076.076 0 00-.04.105c.36.698.771 1.364 1.225 1.994a.076.076 0 00.084.028 19.876 19.876 0 005.993-3.03.077.077 0 00.031-.056c.5-5.177-.838-9.673-3.549-13.661a.061.061 0 00-.031-.028zM8.02 15.331c-1.183 0-2.156-1.085-2.156-2.419 0-1.333.955-2.419 2.156-2.419 1.21 0 2.176 1.096 2.156 2.419 0 1.334-.955 2.419-2.156 2.419zm7.984 0c-1.183 0-2.156-1.085-2.156-2.419 0-1.333.955-2.419 2.156-2.419 1.21 0 2.176 1.096 2.156 2.419 0 1.334-.946 2.419-2.156 2.419z"/>
+      </svg>
+      <span class="txt">Join our Discord</span>
+    </span>
+  </div>
+</a>
+</footer>
     
     <!-- Build Stamp (hidden by default) -->
     <div id="build-stamp" hidden=""></div>
@@ -588,4 +619,5 @@
     <script src="js/matrix-bg.js?v=__BUILD_VER__" defer=""></script>
     <script src="js/back-to-top.js?v=__BUILD_VER__" defer=""></script>
 
+  <script src="js/discord-cta.js" defer></script>
 </body></html>

--- a/js/discord-cta.js
+++ b/js/discord-cta.js
@@ -1,0 +1,29 @@
+(() => {
+  const root = document.querySelector('.vip-discord');
+  const orb  = root?.querySelector('.orb');
+  if (!root || !orb) return;
+  let raf = null, tx = 0, ty = 0, _x = 0, _y = 0;
+  const lerp = (a,b,t)=>a+(b-a)*t;
+  function onMove(e){
+    const r = root.getBoundingClientRect();
+    const nx = (e.clientX - (r.left + r.width/2)) / (r.width/2);
+    const ny = (e.clientY - (r.top  + r.height/2)) / (r.height/2);
+    tx = nx * 6; ty = ny * 6; if(!raf) loop();
+  }
+  function loop(){
+    raf = requestAnimationFrame(loop);
+    _x = lerp(_x, tx, 0.12); _y = lerp(_y, ty, 0.12);
+    orb.style.transform = `translate3d(${_x}px, ${_y}px, 0)`;
+    if (Math.abs(_x - tx) < .05 && Math.abs(_y - ty) < .05) { cancelAnimationFrame(raf); raf = null; }
+  }
+  root.addEventListener('pointerenter', onMove);
+  root.addEventListener('pointermove',  onMove);
+  root.addEventListener('pointerleave', () => { tx = ty = 0; if(!raf) loop(); });
+  const reduce = matchMedia('(prefers-reduced-motion: reduce)');
+  if (reduce.matches) {
+    root.removeEventListener('pointerenter', onMove);
+    root.removeEventListener('pointermove',  onMove);
+    root.removeEventListener('pointerleave', onMove);
+    orb.style.transform = 'none';
+  }
+})();

--- a/scripts/guard-no-linkedin.sh
+++ b/scripts/guard-no-linkedin.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if grep -RInE "https?://(www\.)?linkedin\.com/" -- *.html css js components 2>/dev/null; then
+  echo "❌ Found linkedin.com references. Remove them before merging."
+  exit 1
+fi
+echo "✅ No linkedin.com references detected."

--- a/tests/assert-discord-url-exact.sh
+++ b/tests/assert-discord-url-exact.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+URL='href="https://discord.gg/FJxrnAcawn?utm_source=vipspot&utm_medium=footer&utm_campaign=social_discord"'
+violations=0
+while IFS= read -r -d '' f; do
+  if grep -q 'id="vip-discord"' "$f"; then
+    if ! grep -q "$URL" "$f"; then
+      echo "❌ UTM drift in $f"
+      violations=1
+    fi
+  fi
+done < <(find . -name "*.html" -print0)
+[ $violations -eq 0 ] && echo "✅ Discord CTA URL exact across site."
+exit $violations

--- a/tests/check-discord-cta.sh
+++ b/tests/check-discord-cta.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+grep -RIn 'id="vip-discord"' -- *.html || { echo "❌ Discord CTA not found"; exit 2; }
+grep -RIn 'discord\.gg/FJxrnAcawn' -- *.html || { echo "❌ Discord URL missing"; exit 2; }
+echo "✅ Discord CTA present."


### PR DESCRIPTION
## Summary
- ✅ Added strict UTM drift guard (`assert-discord-url-exact.sh`) to prevent parameter modifications
- ✅ Ensures all Discord CTAs maintain exact canonical URL format
- ✅ Integrates with existing guard suite (LinkedIn + presence checks)
- ✅ Protects carefully crafted UTM tracking parameters from regression

## Test Results
```bash
$ ./scripts/guard-no-linkedin.sh
✅ No linkedin.com references detected.

$ ./tests/check-discord-cta.sh
✅ Discord CTA present.

$ ./tests/assert-discord-url-exact.sh
✅ Discord CTA URL exact across site.
```

## Canonical URL Protected
`https://discord.gg/FJxrnAcawn?utm_source=vipspot&utm_medium=footer&utm_campaign=social_discord`

🤖 Generated with [Claude Code](https://claude.ai/code)