### PR TITLE
fix(csp): include API host in connect-src and form-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     
     <!-- CSP (single line, strict) with Plausible Analytics -->
-    <meta http-equiv="Content-Security-Policy" content="default-src; script-src 'self' https://plausible.io; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event">
+    <meta http-equiv="Content-Security-Policy" content="default-src; script-src 'self' https://plausible.io; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event https://vipspot-api-a7ce781e1397.herokuapp.com; form-action 'self' https://vipspot-api-a7ce781e1397.herokuapp.com">
     
     <!-- Cache control for HTML -->
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">

--- a/scripts/guard-csp-require-api.sh
+++ b/scripts/guard-csp-require-api.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Guard: Ensure API origin is present in CSP connect-src and form-action
+# Required for contact form functionality
+
+set -euo pipefail
+
+API_ORIGIN="https://vipspot-api-a7ce781e1397.herokuapp.com"
+CSP_FILE="index.html"
+
+if [ ! -f "$CSP_FILE" ]; then
+    echo "❌ $CSP_FILE not found"
+    exit 1
+fi
+
+# Extract CSP content between quotes
+CSP_CONTENT=$(grep -o 'Content-Security-Policy" content="[^"]*"' "$CSP_FILE" | sed 's/.*content="//;s/".*//')
+
+if [ -z "$CSP_CONTENT" ]; then
+    echo "❌ No CSP meta tag found in $CSP_FILE"
+    exit 1
+fi
+
+# Check connect-src contains API origin
+if ! echo "$CSP_CONTENT" | grep -q "connect-src [^;]*$API_ORIGIN"; then
+    echo "❌ API origin missing from connect-src directive"
+    echo "Expected: $API_ORIGIN in connect-src"
+    exit 1
+fi
+
+# Check form-action contains API origin  
+if ! echo "$CSP_CONTENT" | grep -q "form-action [^;]*$API_ORIGIN"; then
+    echo "❌ API origin missing from form-action directive"
+    echo "Expected: $API_ORIGIN in form-action"
+    exit 1
+fi
+
+echo "✅ API origin present in both connect-src and form-action"


### PR DESCRIPTION
## Summary
- Add API host `https://vipspot-api-a7ce781e1397.herokuapp.com` to CSP connect-src for API calls
- Add API host to form-action directive for contact form submissions  
- Create guard script `scripts/guard-csp-require-api.sh` to ensure API origin remains in CSP

## Test plan
- [x] All existing guards pass (Plausible, Discord CTA, analytics)
- [x] New CSP API guard validates both connect-src and form-action
- [x] CSP maintains security while enabling contact form functionality

🤖 Generated with [Claude Code](https://claude.ai/code)