### PR TITLE
fix(csp): restore working baseline with style/img/manifest + keep API & Plausible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     
     <!-- CSP (single line, strict) with Plausible Analytics -->
-    <meta http-equiv="Content-Security-Policy" content="default-src; script-src 'self' https://plausible.io; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event https://vipspot-api-a7ce781e1397.herokuapp.com; form-action 'self' https://vipspot-api-a7ce781e1397.herokuapp.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; script-src 'self' https://plausible.io; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event https://vipspot-api-a7ce781e1397.herokuapp.com; form-action 'self' https://vipspot-api-a7ce781e1397.herokuapp.com">
     
     <!-- Cache control for HTML -->
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">


### PR DESCRIPTION
## Summary
- Add `default-src 'self'` for baseline resource loading
- Add `style-src 'self' 'unsafe-inline'` for CSS and inline styles
- Add `img-src 'self' data:` for images and data URIs  
- Add `manifest-src 'self'` for web app manifest
- Keep existing API host and Plausible analytics allowances

## Problem
Previous CSP was too restrictive and blocked essential resources (styles, images, manifest), breaking the site deployment.

## Solution
Restore hardened-but-working baseline while preserving the API and Plausible integrations.

## Test plan
- [x] All guards pass (API, Plausible, Discord CTA, analytics)
- [x] CSP allows essential resources while maintaining security

🤖 Generated with [Claude Code](https://claude.ai/code)