### PR TITLE
fix(csp): add script-src directive for Plausible script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     
     <!-- CSP (single line, strict) with Plausible Analytics -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event https://vipspot-api-a7ce781e1397.herokuapp.com; form-action 'self' https://vipspot-api-a7ce781e1397.herokuapp.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; script-src 'self' https://plausible.io; script-src-elem 'self' https://plausible.io; connect-src 'self' https://plausible.io https://plausible.io/api/event https://vipspot-api-a7ce781e1397.herokuapp.com; form-action 'self' https://vipspot-api-a7ce781e1397.herokuapp.com">
     
     <!-- Cache control for HTML -->
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">


### PR DESCRIPTION
## Problem
Plausible analytics script still blocked by CSP:
> https://plausible.io/js/script.js blocked script-src-elem

## Root Cause  
Missing `script-src` directive. Browsers need BOTH:
- `script-src-elem` for external script tags
- `script-src` for inline scripts and as fallback

## Solution
- Add `script-src 'self' https://plausible.io` alongside existing `script-src-elem`
- Both directives now allow Plausible domain
- Maintains security for all other resources

## Test plan
- [x] All guards pass (API, Plausible alignment)
- [x] Both script directives include Plausible

🤖 Generated with [Claude Code](https://claude.ai/code)